### PR TITLE
update for rust 0.12.0-pre (or 0.11)

### DIFF
--- a/patterns/abstract_factory.rs
+++ b/patterns/abstract_factory.rs
@@ -30,19 +30,19 @@ trait Factory<P: Phone, T: Tablet> {
  * Define our Apple products. Normally these structs would contain a lot more
  * data.
  */
-struct iPhone;
+struct IPhone;
 
-impl Phone for iPhone {
+impl Phone for IPhone {
     fn call(&self) {
-        println("Look! I'm calling on an iPhone!");
+        println!("Look! I'm calling on an IPhone!");
     }
 }
 
-struct iPad;
+struct IPad;
 
-impl Tablet for iPad {
+impl Tablet for IPad {
     fn play_games(&self) {
-        println("Just playing some games on my iPad.");
+        println!("Just playing some games on my IPad.");
     }
 }
 
@@ -51,13 +51,13 @@ impl Tablet for iPad {
  */
 struct AppleFactory;
 
-impl Factory<iPhone, iPad> for AppleFactory {
-    fn new_phone(&self) -> iPhone {
-        return iPhone;
+impl Factory<IPhone, IPad> for AppleFactory {
+    fn new_phone(&self) -> IPhone {
+        return IPhone;
     }
 
-    fn new_tablet(&self) -> iPad {
-        return iPad;
+    fn new_tablet(&self) -> IPad {
+        return IPad;
     }
 }
 
@@ -70,7 +70,7 @@ struct Nexus4;
 
 impl Phone for Nexus4 {
     fn call(&self) {
-        println("Look! I'm calling on a Nexus 4!");
+        println!("Look! I'm calling on a Nexus 4!");
     }
 }
 
@@ -78,7 +78,7 @@ struct Nexus10;
 
 impl Tablet for Nexus10 {
     fn play_games(&self) {
-        println("Just playing some games on my Nexus 10.");
+        println!("Just playing some games on my Nexus 10.");
     }
 }
 

--- a/patterns/adapter.rs
+++ b/patterns/adapter.rs
@@ -23,19 +23,19 @@ struct NASAShip;
  */
 impl RocketShip for NASAShip {
     fn turn_on(&self) {
-        println("NASA Ship is turning on.")
+        println!("NASA Ship is turning on.")
     }
 
     fn turn_off(&self) {
-        println("NASA Ship is turning off.")
+        println!("NASA Ship is turning off.")
     }
 
     fn blast_off(&self) {
-        println("NASA Ship is blasting off.")
+        println!("NASA Ship is blasting off.")
     }
 
     fn fly(&self) {
-        println("NASA Ship is flying away.")
+        println!("NASA Ship is flying away.")
     }
 }
 
@@ -61,23 +61,23 @@ struct SpaceXDragon;
  */
 impl SpaceXShip for SpaceXDragon {
     fn ignition(&self) {
-        println("Turning Dragon's ignition.")
+        println!("Turning Dragon's ignition.")
     }
 
     fn on(&self) {
-        println("Turning on the Dragon.")
+        println!("Turning on the Dragon.")
     }
 
     fn off(&self) {
-        println("Turning off the Dragon.")
+        println!("Turning off the Dragon.")
     }
 
     fn launch(&self) {
-        println("Launching the Dragon")
+        println!("Launching the Dragon")
     }
 
     fn fly(&self) {
-        println("The Dragon is flying away.")
+        println!("The Dragon is flying away.")
     }
 }
 
@@ -123,7 +123,7 @@ fn pilot<S: RocketShip>(ship: &S) {
     ship.blast_off();
     ship.fly();
     ship.turn_off();
-    print("\n");
+    print!("\n");
 }
 
 fn main() {
@@ -131,7 +131,7 @@ fn main() {
     let saturn5 = NASAShip;
 
     // Let's fly our NASAShip
-    println("Piloting the Saturn 5.");
+    println!("Piloting the Saturn 5.");
     pilot(&saturn5);
 
     // Create a Dragon
@@ -146,6 +146,6 @@ fn main() {
     };
 
     // Now we can pilot the Dragon!
-    println("Piloting the Dragon Adapter.");
+    println!("Piloting the Dragon Adapter.");
     pilot(&dragon_adapter);
 }


### PR DESCRIPTION
`println` was changed in Rust a while back to the `println!()` macro, which is now reflected in the code.

All Rust code, excluding your `chain_of_responsibility.rs` (unimplemented) now compiles on Rust

```
rustc 0.12.0-pre
```

commit

```
e178ebf681d532c1c965883ae34788713f748960
```

The `iPhone` -> `IPhone` change might be controversial - it's now linted by the Rust compiler (so the old code throws a warning), and while these can be hidden, the current [naming conventions guidelines](http://aturon.github.io/style/naming.html) suggest camelcase structs ...

Also, this should compile with `rustc 0.11` just as easily as with the nightlies. It's not exactly a major change.
